### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,8 @@ parts:
     source: .
     plugin: go
     go-importpath: github.com/flow-lab/flow
+    build-attributes: [no-patchelf]
 
 apps:
   flow:
-    command: flow
+    command: bin/flow


### PR DESCRIPTION
Fixed the yaml.
Adding the path to the `command` will ensure it doesn't loop. The `no-patchelf` will prevent snapcraft from munging the binary. However, this resulting binary may not work on all systems.